### PR TITLE
docs: add Mermaid architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Conjunto de modulos Python para analise e simulacao de estrategias de trading de
 | `src/validate_data.py` | Validador de schema CSV (colunas obrigatorias, tipos, valores nulos) |
 | `config/` | Configuracao YAML com parametros de trading, dados e modelos |
 
+### Arquitetura
+
+```mermaid
+graph TD
+    CFG["config/config.py<br/>Loader de Configuracao YAML"] --> ENG
+    VD["validate_data.py<br/>Validador de Schema CSV"] --> FE
+    FE["data/features.py<br/>Feature Engineering"] --> ENG["backtesting/engine.py<br/>Engine de Backtesting"]
+    ENG --> MET["backtesting/metrics.py<br/>Metricas Financeiras"]
+    ENG --> VIS["backtesting/visualization.py<br/>Graficos de Equity & Drawdown"]
+    FE --> RL["models/reinforcement_learning.py<br/>Agentes DQN & PPO"]
+    OM["execution/order_manager.py<br/>Gerenciador de Ordens Async"] --> SL["execution/slippage.py<br/>Calculo de Slippage"]
+    OM --> LAT["execution/latency.py<br/>Monitor de Latencia"]
+    FE --> DASH["dashboard.py<br/>Dashboard Streamlit"]
+```
+
 ### Estrutura
 
 ```
@@ -138,6 +153,21 @@ Collection of Python modules for high-frequency trading analysis and simulation.
 | `src/dashboard.py` | Streamlit dashboard for interactive feature visualization |
 | `src/validate_data.py` | CSV schema validator (required columns, types, null values) |
 | `config/` | YAML configuration with trading, data, and model parameters |
+
+### Architecture
+
+```mermaid
+graph TD
+    CFG["config/config.py<br/>YAML Config Loader"] --> ENG
+    VD["validate_data.py<br/>CSV Schema Validator"] --> FE
+    FE["data/features.py<br/>Feature Engineering"] --> ENG["backtesting/engine.py<br/>Backtesting Engine"]
+    ENG --> MET["backtesting/metrics.py<br/>Financial Metrics"]
+    ENG --> VIS["backtesting/visualization.py<br/>Equity & Drawdown Charts"]
+    FE --> RL["models/reinforcement_learning.py<br/>DQN & PPO Agents"]
+    OM["execution/order_manager.py<br/>Async Order Manager"] --> SL["execution/slippage.py<br/>Slippage Calculation"]
+    OM --> LAT["execution/latency.py<br/>Latency Monitor"]
+    FE --> DASH["dashboard.py<br/>Streamlit Dashboard"]
+```
 
 ### Usage
 


### PR DESCRIPTION
### **User description**
Add Mermaid flowcharts showing module relationships in both PT-BR and EN sections.


___

### **PR Type**
Documentation


___

### **Description**
- Add Mermaid architecture diagram showing module relationships

- Include diagram in both Portuguese and English sections

- Visualize data flow from config through backtesting to execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CFG["config/config.py"] --> ENG["backtesting/engine.py"]
  VD["validate_data.py"] --> FE["data/features.py"]
  FE --> ENG
  ENG --> MET["backtesting/metrics.py"]
  ENG --> VIS["backtesting/visualization.py"]
  FE --> RL["models/reinforcement_learning.py"]
  FE --> DASH["dashboard.py"]
  OM["execution/order_manager.py"] --> SL["execution/slippage.py"]
  OM --> LAT["execution/latency.py"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add architecture diagrams in PT-BR and EN</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add Mermaid architecture diagram in Portuguese section showing module <br>dependencies and data flow<br> <li> Add identical Mermaid architecture diagram in English section with <br>translated labels<br> <li> Diagrams illustrate relationships between config loader, validators, <br>feature engineering, backtesting engine, metrics, visualization, <br>reinforcement learning models, order management, and dashboard <br>components</ul>


</details>


  </td>
  <td><a href="https://github.com/galafis/high-frequency-trading-analytics/pull/3/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

